### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/DGNCrypt/d954c8bb-2360-43e2-9359-0fe4f60b028e/c7165275-7583-4aea-aefd-9f1314da3cdd/_apis/work/boardbadge/731220d0-b501-47fe-b323-bf01898ed5a3)](https://dev.azure.com/DGNCrypt/d954c8bb-2360-43e2-9359-0fe4f60b028e/_boards/board/t/c7165275-7583-4aea-aefd-9f1314da3cdd/Microsoft.RequirementCategory)
 # .github-workflows
 superlinter.yml


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/DGNCrypt/d954c8bb-2360-43e2-9359-0fe4f60b028e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.